### PR TITLE
Continuous scraping production scale up

### DIFF
--- a/scrapy_pyronear/README.md
+++ b/scrapy_pyronear/README.md
@@ -1,12 +1,12 @@
-## PIPELINE DE SCRAPPING D'IMAGES ALERTWEST
+# AlertWest Image Scraping Pipeline
 
-Pipeline de scraping d'images de caméras de surveillance du site alertwest.org pour l'entraînement d'un modèle de détection de départs de feu.
+This repository provides a high‑throughput Scrapy pipeline to download camera images from AlertWest, plus a continuous runner to execute the spider at a fixed interval.
 
-## Prérequis
+# ===== STARTER INFO =====
+## Prerequisites
 
-- **Python 3.12.0**
-- **Conda** ou **pip** pour la gestion des dépendances
-
+- Python 3.12.0
+- Conda or pip for dependency management
 
 ## Installation
 
@@ -16,39 +16,59 @@ conda activate pyronear
 pip install -r requirements.txt
 ```
 
-## Démarrage rapide
+# ===== RUNNING INFO =====
+## Continuous Scraping (recommended entrypoint)
 
-### Lancer le scraping
+The continuous runner is the easiest way to keep images up‑to‑date.
+
+- What it does: repeatedly launches the Scrapy spider at a fixed interval (no overlap). It logs each cycle, handles Ctrl+C gracefully, and reuses your Scrapy project settings, spider, and pipelines.
+- How it works with Scrapy: it shells out `scrapy crawl alertwest` inside this project, so the spider, pipelines, and `settings.py` remain the single source of truth. The runner only schedules runs; it doesn’t change scraping logic.
+
+### Quick start
+
+```bash
+# Default interval (60s)
+python continuous_scraper.py
+
+# Custom interval (e.g., 90s)
+python continuous_scraper.py --interval 90
+```
+
+Notes
+- Graceful stop: press Ctrl+C; the current cycle finishes, then the runner exits.
+- If a cycle takes longer than the interval, the next cycle starts immediately after.
+- Outputs: `alertwest.json` is overwritten each cycle (per `settings.py`), and images are saved under `images/`.
+
+## One‑off crawl (single run)
 
 ```bash
 scrapy crawl alertwest
 ```
 
-### Lancer avec paramètres personnalisés
+### Run with custom parameters
 
 ```bash
 scrapy crawl alertwest -s DOWNLOAD_TIMEOUT=3 CONCURRENT_ITEMS=100
 ```
 
-### Paramètres disponibles cf `settings.py`
+### Common settings (see `settings.py`)
 
-Exemples :
+Examples:
 
-| Paramètre | Défaut | Description |
-|-----------|--------|-------------|
-| `DOWNLOAD_TIMEOUT` | 2s | Délai maximal pour télécharger une image |
-| `CONCURRENT_ITEMS` | 400 | Nombre d'items traités en parallèle dans la pipeline |
-| `CONCURRENT_REQUESTS` | 64 | Nombre maximal de requêtes HTTP simultanées |
-| `CONCURRENT_REQUESTS_PER_DOMAIN` | 32 | Requêtes simultanées par domaine |
+| Setting | Default | Description |
+|--------|---------|-------------|
+| `DOWNLOAD_TIMEOUT` | 2s | Max time to download an image |
+| `CONCURRENT_ITEMS` | 400 | Parallel items processed in the pipeline |
+| `CONCURRENT_REQUESTS` | 64 | Max concurrent HTTP requests |
+| `CONCURRENT_REQUESTS_PER_DOMAIN` | 32 | Concurrent requests per domain |
 
-
-### Exporter les métadonnées en JSON
+### Export metadata to JSON
 
 ```bash
 scrapy crawl alertwest -o alertwest.json
 ```
 
-### Mode debug
+### Debug mode
 
 ```bash
 scrapy crawl alertwest -s LOG_LEVEL=DEBUG
@@ -64,98 +84,97 @@ pytest -v tests/
 pytest -v .\tests\
 ```
 
-## Architecture
+## Project structure
 
 ```
 scrappy_pyronear/
 ├── spiders/
-│   └── alertwest_spider.py      # Spider principal
-├── items.py                      # Définition des items
-├── pipelines.py                  # Pipeline de téléchargement d'images
-├── settings.py                   # Configuration Scrapy
-└── logformatter.py               # Formatter personnalisé pour les logs
-images/                           # Répertoire de sortie (généré)
-tests/                            # Tests unitaires
-alertwest.json                    # Export JSON des métadonnées (optionnel)
+│   └── alertwest_spider.py      # Main spider
+├── items.py                     # Item definitions
+├── pipelines.py                 # Image download pipeline
+├── settings.py                  # Scrapy configuration
+└── logformatter.py              # Custom log formatter
+images/                          # Output directory (generated)
+tests/                           # Unit tests
+alertwest.json                   # Optional JSON export of metadata
 ```
 
-## Mécanisme de scraping
+## How it works
 
-### 1. Spider (`alertwest_spider.py`)
+### 1) Spider (`alertwest_spider.py`)
 
-- Envoie une requête GET vers l'API AlertWest.
-- Parse la réponse JSON pour extraire :
-  - `key_list` : mapping des clés courtes vers les noms de propriétés.
-  - `data_cams` : liste des caméras.
-- Mappe les propriétés intéressantes (Azimuth, camId, Screenshot, camLastMoved, etc.) vers leurs clés respectives.
-- Pour chaque caméra, construit l'URL d'image au format :
-  ```
-  https://img.cdn.prod.alertwest.com/data/thumb/{cam_id}/{YYYY/MM/DD}/{img_name}
-  ```
-- Yield des items `PyronearItem` avec métadonnées et URL.
+- Sends a GET request to the AlertWest API.
+- Parses the JSON response to extract:
+  - `key_list`: mapping from short keys to property names.
+  - `data_cams`: the list of cameras.
+- Maps interesting properties (Azimuth, camId, Screenshot, camLastMoved, camName, etc.) to their short keys.
+- For each camera, builds the image URL:
 
-### 2. Items (`items.py`)
+```
+https://img.cdn.prod.alertwest.com/data/img/{cam_id}/{YYYY/MM/DD}/{img_name}
+```
 
-`PyronearItem` contient les champs :
-- `id` : identifiant unique de la caméra
-- `name` : nom de la caméra
-- `azimuth` : orientation de la caméra
-- `last_moved` : timestamp du dernier mouvement
-- `image_url` : URL de l'image à télécharger
-- `valid_url` : indicateur de validité de l'URL
+- Yields `PyronearItem` objects with metadata and `image_url`.
 
-### 3. Pipeline (`pipelines.py`)
+### 2) Items (`items.py`)
 
-Hérite de `scrapy.pipelines.images.ImagesPipeline` et :
+`PyronearItem` fields:
+- `id`: camera identifier
+- `name`: camera name
+- `azimuth`: camera orientation
+- `last_moved`: last movement timestamp
+- `image_url`: image URL to download
+- `valid_url`: URL validity flag
 
-| Méthode | Rôle |
-|---------|------|
-| `open_spider()` | Initialise les compteurs, timers et barre de progression |
-| `get_media_requests()` | Génère les requêtes de téléchargement d'images en parallèle |
-| `media_failed()` | Capture les erreurs (timeouts, connexions perdues) et met à jour les compteurs |
-| `file_path()` | Définit la structure de stockage : `{cam_id}/{azimuth}/{cam_id}.jpg` |
-| `close_spider()` | Affiche un résumé (échecs, URLs manquantes, temps écoulé) |
+### 3) Pipeline (`pipelines.py`)
 
-### 4. Optimisations de concurrence
+Inherits from `scrapy.pipelines.images.ImagesPipeline` and:
 
-- `CONCURRENT_REQUESTS = 64` : limite globale pour éviter de surcharger le réseau
-- `CONCURRENT_REQUESTS_PER_DOMAIN = 32` : limite par domaine pour respecter les serveurs
-- `CONCURRENT_ITEMS = 400` : traitement parallèle des items dans la pipeline
-- `RETRY_ENABLED = False` : pas de retry sur les timeouts (gagne du temps)
-- `DOWNLOAD_TIMEOUT = 2s` : timeout agressif pour favoriser la vitesse
+| Method | Purpose |
+|--------|---------|
+| `open_spider()` | Initializes counters, timers, and a progress bar |
+| `get_media_requests()` | Generates parallel image download requests |
+| `media_failed()` | Captures errors (timeouts, connection issues) and updates counters |
+| `file_path()` | Storage structure: `{cam_id}/{azimuth}/{cam_id}_{scraping_timestamp}.jpg` |
+| `close_spider()` | Prints a summary (failures, missing URLs, elapsed time) |
 
-### 5. Gestion des erreurs
+### 4) Concurrency tuning
 
-Un `LogFormatter` personnalisé silencieux les logs de timeout pour garder une sortie propre. Les erreurs sont comptabilisées :
-- **Timeouts** : images non téléchargées à cause du délai
-- **Caméras down** : serveur a rejeté la requête (HTTP 4xx/5xx)
-- **URLs manquantes** : paramètres manquants dans la réponse JSON
+- `CONCURRENT_REQUESTS = 64`: avoid overwhelming the network
+- `CONCURRENT_REQUESTS_PER_DOMAIN = 32`: be polite to the remote host
+- `CONCURRENT_ITEMS = 400`: speed up pipeline processing
+- `RETRY_ENABLED = False`: skip retries for faster throughput
+- `DOWNLOAD_TIMEOUT = 2s`: aggressive timeout for speed (tune as needed)
 
-### 6. Arbore de stockage des images
+### 5) Error handling
+
+A custom `LogFormatter` silences timeout noise. Counters track:
+- Timeouts: images not downloaded due to deadlines
+- Camera down: HTTP 4xx/5xx
+- Missing URLs: incomplete JSON preventing URL construction
+
+### 6) Image storage structure
 
 ```
 images/
 └── {cam_id}/
       └── {azimuth}/
             └── {cam_id}_{scraping_timestamp}.jpg
-                 
-            
-
 ```
 
 ## Configuration
 
-Tous les paramètres Scrapy se trouvent dans `settings.py`. Les principaux :
+Key Scrapy options in `settings.py`:
 
 ```python
-CONCURRENT_REQUESTS = 64                    # Requêtes HTTP simultanées
-CONCURRENT_ITEMS = 400                      # Items en parallèle
-DOWNLOAD_TIMEOUT = 2                        # Timeout (secondes)
-RETRY_ENABLED = False                       # Pas de retry
+CONCURRENT_REQUESTS = 64
+CONCURRENT_ITEMS = 400
+DOWNLOAD_TIMEOUT = 2
+RETRY_ENABLED = False
 LOG_FORMATTER = "scrappy_pyronear.logformatter.SilentTimeoutLogFormatter"
 ```
 
-## Exemple de sortie
+## Output example
 
 ```
 Downloading images 🚀 : 100%|█████████████████████████████| 11702/11702 images
@@ -166,22 +185,21 @@ Timed out for 45 cameras among 11702 total cameras.
 Time taken: 2.53 minutes
 ```
 
-## Dépannage
+## Helpers for troubleshooting
 
-### Scraping lent
+### Slow scraping
 
-Augmentez les paramètres de concurrence :
+Increase concurrency:
 ```bash
 scrapy crawl alertwest -s CONCURRENT_REQUESTS=128 CONCURRENT_ITEMS=500
 ```
 
-### Trop de timeouts
+### Too many timeouts
 
-Augmentez le délai :
+Increase the timeout:
 ```bash
 scrapy crawl alertwest -s DOWNLOAD_TIMEOUT=10
 ```
-
 
 
 ## Mécanisme de scraping (détail technique)
@@ -195,7 +213,7 @@ scrapy crawl alertwest -s DOWNLOAD_TIMEOUT=10
      - Pour chaque caméra dans `data_cams` :
          - Lit les valeurs (id, nom, azimut, timestamp, nom d'image).
          - Si `cam_id` et `img_name` sont présents, construit l'URL d'image :
-             `https://img.cdn.prod.alertwest.com/data/thumb/{cam_id}/{YYYY/MM/DD}/{img_name}` (la date utilisée est la date courante).
+             `https://img.cdn.prod.alertwest.com/data/img/{cam_id}/{YYYY/MM/DD}/{img_name}` (la date utilisée est la date courante).
          - Crée un `PyronearItem` avec les champs remplis et le `image_url` construit, puis `yield item`.
 
 2. Items (`scrappy_pyronear/items.py`) :
@@ -209,7 +227,7 @@ scrapy crawl alertwest -s DOWNLOAD_TIMEOUT=10
              - Appelée pour chaque `item`. Si `item['image_url']` existe, elle met à jour la barre de progression puis retourne une `scrapy.Request` pointant vers l'URL d'image en transférant les métadonnées utiles via `meta` (ex : `id`, `azimuth`, `last_moved`).
              - Si l'URL est absente, incrémente un compteur `no_url`.
          - `media_failed(self, failure, request, info)` : intercepte les erreurs réseau/timout et incrémente des compteurs (`timeout_cam`, `failed_cam`) selon la nature de l'erreur.
-         - `file_path(self, request, response=None, info=None, item=None)` : construit le chemin local de sauvegarde pour chaque image. Format : ``{cam_id}/{azimuth}/{cam_id}.jpg`` (azimuth vaut `unknown` si absent).
+         - `file_path(self, request, response=None, info=None, item=None)` : construit le chemin local de sauvegarde pour chaque image. Format : ``{cam_id}/{azimuth}/{cam_id}_{scraping_timestamp}.jpg`` (azimuth vaut `unknown` si absent).
          - `close_spider(self, spider)` : affiche un résumé (nombre d'échecs, d'URLs manquantes, temps écoulé) et ferme la barre de progression.
 
 4. Réglages clés (`scrappy_pyronear/settings.py`) :

--- a/scrapy_pyronear/README.md
+++ b/scrapy_pyronear/README.md
@@ -1,55 +1,176 @@
-# Pyronear
-Pipeline de scrapping d'images de caméras de surveillance pour entrainement d'un modèle de détection de départs de feu.
+## PIPELINE DE SCRAPPING D'IMAGES ALERTWEST
 
-### Commande pour se placer dans le bon dossier 
+Pipeline de scraping d'images de caméras de surveillance du site alertwest.org pour l'entraînement d'un modèle de détection de départs de feu.
 
+## Prérequis
+
+- **Python 3.12.0**
+- **Conda** ou **pip** pour la gestion des dépendances
+
+
+## Installation
+
+```bash
+conda create --name pyronear python=3.12
+conda activate pyronear
+pip install -r requirements.txt
 ```
-cd Pyronear
-```
 
-### Lancer le scrapping des images 
+## Démarrage rapide
 
-```
+### Lancer le scraping
+
+```bash
 scrapy crawl alertwest
 ```
 
-### Utiliser les paramètres pour ajuster le scrapping
+### Lancer avec paramètres personnalisés
 
-```
-scrapy crawl alertwest -s
-    DOWNLOAD_TIMEOUT=3 # Temps maximum (en secondes) pour télécharger une image
-    CONCURRENT_ITEMS=100 # Nombre d'items traités en parallèle
+```bash
+scrapy crawl alertwest -s DOWNLOAD_TIMEOUT=3 CONCURRENT_ITEMS=100
 ```
 
-### Lancer le scrapping des images ET enregistrement du json 
+### Paramètres disponibles cf `settings.py`
 
-```
+Exemples :
+
+| Paramètre | Défaut | Description |
+|-----------|--------|-------------|
+| `DOWNLOAD_TIMEOUT` | 2s | Délai maximal pour télécharger une image |
+| `CONCURRENT_ITEMS` | 400 | Nombre d'items traités en parallèle dans la pipeline |
+| `CONCURRENT_REQUESTS` | 64 | Nombre maximal de requêtes HTTP simultanées |
+| `CONCURRENT_REQUESTS_PER_DOMAIN` | 32 | Requêtes simultanées par domaine |
+
+
+### Exporter les métadonnées en JSON
+
+```bash
 scrapy crawl alertwest -o alertwest.json
 ```
-## Lancer les tests 
 
-```
-pytest -v .\test\test_alertwest_spider.py
-```
+### Mode debug
 
-## Lancer en mode debug
-
-```
+```bash
 scrapy crawl alertwest -s LOG_LEVEL=DEBUG
 ```
 
-## Structure du dépôt
+## Tests
 
-Ce dépôt contient un mini-projet Scrapy pour récupérer des images issues de l'API AlertWest et les stocker localement pour l'entraînement.
+```bash
+# Bash / Linux / macOS
+pytest -v tests/
 
-- `scrappy_pyronear/` : package Scrapy principal
-    - `spiders/alertwest_spider.py` : spider qui interroge l'API AlertWest, parse le JSON et yield des items (`PyronearItem`).
-    - `items.py` : définition de l'item `PyronearItem` (champs : `id`, `name`, `azimuth`, `last_moved`, `image_url`, `valid_url`).
-    - `pipelines.py` : pipeline `AlertwestImagePipeline` qui télécharge les images, gère la progression et les erreurs, et crée l'arborescence de stockage.
-    - `settings.py` : réglages Scrapy (concurrency, timeouts, export JSON, log formatter, etc.).
-- `images/` : répertoire de destination (généré par le pipeline) contenant les dossiers par `cam_id` et `azimuth`.
-- `alertwest.json` : export JSON possible des métadonnées (via le feed ou option `-o`).
-- `tests/` : tests unitaires.
+# Windows PowerShell
+pytest -v .\tests\
+```
+
+## Architecture
+
+```
+scrappy_pyronear/
+├── spiders/
+│   └── alertwest_spider.py      # Spider principal
+├── items.py                      # Définition des items
+├── pipelines.py                  # Pipeline de téléchargement d'images
+├── settings.py                   # Configuration Scrapy
+└── logformatter.py               # Formatter personnalisé pour les logs
+images/                           # Répertoire de sortie (généré)
+tests/                            # Tests unitaires
+alertwest.json                    # Export JSON des métadonnées (optionnel)
+```
+
+## Mécanisme de scraping
+
+### 1. Spider (`alertwest_spider.py`)
+
+- Envoie une requête GET vers l'API AlertWest.
+- Parse la réponse JSON pour extraire :
+  - `key_list` : mapping des clés courtes vers les noms de propriétés.
+  - `data_cams` : liste des caméras.
+- Mappe les propriétés intéressantes (Azimuth, camId, Screenshot, camLastMoved, etc.) vers leurs clés respectives.
+- Pour chaque caméra, construit l'URL d'image au format :
+  ```
+  https://img.cdn.prod.alertwest.com/data/thumb/{cam_id}/{YYYY/MM/DD}/{img_name}
+  ```
+- Yield des items `PyronearItem` avec métadonnées et URL.
+
+### 2. Items (`items.py`)
+
+`PyronearItem` contient les champs :
+- `id` : identifiant unique de la caméra
+- `name` : nom de la caméra
+- `azimuth` : orientation de la caméra
+- `last_moved` : timestamp du dernier mouvement
+- `image_url` : URL de l'image à télécharger
+- `valid_url` : indicateur de validité de l'URL
+
+### 3. Pipeline (`pipelines.py`)
+
+Hérite de `scrapy.pipelines.images.ImagesPipeline` et :
+
+| Méthode | Rôle |
+|---------|------|
+| `open_spider()` | Initialise les compteurs, timers et barre de progression |
+| `get_media_requests()` | Génère les requêtes de téléchargement d'images en parallèle |
+| `media_failed()` | Capture les erreurs (timeouts, connexions perdues) et met à jour les compteurs |
+| `file_path()` | Définit la structure de stockage : `{cam_id}/{azimuth}/{cam_id}.jpg` |
+| `close_spider()` | Affiche un résumé (échecs, URLs manquantes, temps écoulé) |
+
+### 4. Optimisations de concurrence
+
+- `CONCURRENT_REQUESTS = 64` : limite globale pour éviter de surcharger le réseau
+- `CONCURRENT_REQUESTS_PER_DOMAIN = 32` : limite par domaine pour respecter les serveurs
+- `CONCURRENT_ITEMS = 400` : traitement parallèle des items dans la pipeline
+- `RETRY_ENABLED = False` : pas de retry sur les timeouts (gagne du temps)
+- `DOWNLOAD_TIMEOUT = 2s` : timeout agressif pour favoriser la vitesse
+
+### 5. Gestion des erreurs
+
+Un `LogFormatter` personnalisé silencieux les logs de timeout pour garder une sortie propre. Les erreurs sont comptabilisées :
+- **Timeouts** : images non téléchargées à cause du délai
+- **Caméras down** : serveur a rejeté la requête (HTTP 4xx/5xx)
+- **URLs manquantes** : paramètres manquants dans la réponse JSON
+
+## Configuration
+
+Tous les paramètres Scrapy se trouvent dans `settings.py`. Les principaux :
+
+```python
+CONCURRENT_REQUESTS = 64                    # Requêtes HTTP simultanées
+CONCURRENT_ITEMS = 400                      # Items en parallèle
+DOWNLOAD_TIMEOUT = 2                        # Timeout (secondes)
+RETRY_ENABLED = False                       # Pas de retry
+LOG_FORMATTER = "scrappy_pyronear.logformatter.SilentTimeoutLogFormatter"
+```
+
+## Exemple de sortie
+
+```
+Downloading images 🚀 : 100%|█████████████████████████████| 11702/11702 images
+
+URL retrieved but camera is down for 1524 cameras among 11702 total cameras.
+Miss a parameter in the json to construct URL for 999 cameras among 11702 total cameras.
+Timed out for 45 cameras among 11702 total cameras.
+Time taken: 2.53 minutes
+```
+
+## Dépannage
+
+### Scraping lent
+
+Augmentez les paramètres de concurrence :
+```bash
+scrapy crawl alertwest -s CONCURRENT_REQUESTS=128 CONCURRENT_ITEMS=500
+```
+
+### Trop de timeouts
+
+Augmentez le délai :
+```bash
+scrapy crawl alertwest -s DOWNLOAD_TIMEOUT=10
+```
+
+
 
 ## Mécanisme de scraping (détail technique)
 

--- a/scrapy_pyronear/README.md
+++ b/scrapy_pyronear/README.md
@@ -131,6 +131,18 @@ Un `LogFormatter` personnalisé silencieux les logs de timeout pour garder une s
 - **Caméras down** : serveur a rejeté la requête (HTTP 4xx/5xx)
 - **URLs manquantes** : paramètres manquants dans la réponse JSON
 
+### 6. Arbore de stockage des images
+
+```
+images/
+└── {cam_id}/
+      └── {azimuth}/
+            └── {cam_id}_{scraping_timestamp}.jpg
+                 
+            
+
+```
+
 ## Configuration
 
 Tous les paramètres Scrapy se trouvent dans `settings.py`. Les principaux :

--- a/scrapy_pyronear/continuous_scraper.py
+++ b/scrapy_pyronear/continuous_scraper.py
@@ -1,0 +1,157 @@
+"""
+Script de scraping continu pour AlertWest.
+
+Ce script lance la spider alertwest de manière continue avec un intervalle
+configurable entre chaque exécution.
+
+Usage:
+    python continuous_scraper.py [--interval SECONDS]
+
+Options:
+    --interval SECONDS  Intervalle en secondes entre chaque scraping (défaut: 30)
+
+Exemple:
+    python continuous_scraper.py --interval 60  # Lance le scraping toutes les 60 secondes
+"""
+
+import argparse
+import logging
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Configuration du logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+
+class ContinuousScraper:
+    """Gestionnaire de scraping continu."""
+    
+    def __init__(self, interval_seconds=30):
+        """
+        Initialise le scraper continu.
+        
+        Args:
+            interval_seconds (int): Intervalle en secondes entre chaque scraping
+        """
+        self.interval_seconds = interval_seconds
+        self.running = True
+        self.scrape_count = 0
+        
+        # Gestion des signaux pour arrêt propre
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+    
+    def _signal_handler(self, signum, frame):
+        """Handles stop signals (Ctrl+C, etc.)."""
+        logger.info("Stop signal received. Stopping after the current cycle...")
+        self.running = False
+    
+    def run_spider_once(self):
+        """
+        Lance la spider une seule fois via subprocess.
+        
+        Returns:
+            bool: True si le scraping s'est bien déroulé, False sinon
+        """
+        try:
+            logger.info(f"🚀 Start of scraping cycle #{self.scrape_count + 1}")
+            start_time = time.time()
+            
+            # Lance scrapy crawl en subprocess
+            result = subprocess.run(
+                ['scrapy', 'crawl', 'alertwest'],
+                cwd=Path(__file__).parent,
+                capture_output=False,  # Affiche la sortie en temps réel
+                text=True
+            )
+            
+            elapsed_time = time.time() - start_time
+            self.scrape_count += 1
+            
+            if result.returncode == 0:
+                logger.info(f"✅ Cycle #{self.scrape_count} finished in {elapsed_time:.2f} seconds")
+                return True
+            else:
+                logger.error(f"❌ Cycle #{self.scrape_count} failed with code {result.returncode}")
+                return False
+            
+        except Exception as e:
+            logger.error(f"❌ Error during scraping: {e}", exc_info=True)
+            return False
+    
+    def run(self):
+        """Run continuous scraping with the specified interval."""
+        logger.info(f"🔄 Starting continuous scraping (interval: {self.interval_seconds}s)")
+        logger.info("Press Ctrl+C to stop gracefully")
+        
+        while self.running:
+            cycle_start = time.time()
+            
+            # Lance un cycle de scraping
+            success = self.run_spider_once()
+            
+            if not self.running:
+                break
+            
+            # Calcule le temps d'attente avant le prochain cycle
+            elapsed = time.time() - cycle_start
+            wait_time = max(0, self.interval_seconds - elapsed)
+            
+            if wait_time > 0:
+                logger.info(f"⏳ Waiting {wait_time:.2f}s before the next cycle...")
+                
+                # Temps d'attente avec possibilité d'arrêt
+                sleep_start = time.time()
+                while (time.time() - sleep_start) < wait_time and self.running:
+                    time.sleep(min(1, wait_time - (time.time() - sleep_start)))
+            else:
+                logger.warning(
+                    f"⚠️  The cycle took {elapsed:.2f}s, "
+                    f"longer than the interval of {self.interval_seconds}s"
+                )
+        
+        logger.info(f"🛑 Stopping continuous scraping. Total cycles completed: {self.scrape_count}")
+
+
+def main():
+    """Point d'entrée principal du script."""
+    parser = argparse.ArgumentParser(
+        description="Continuous scraping script for AlertWest",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples of usage:
+  python continuous_scraper.py                    # Default interval (60s)
+  python continuous_scraper.py --interval 90      # Every 90 seconds
+  python continuous_scraper.py --interval 300     # Every 5 minutes
+        """
+    )
+    
+    parser.add_argument(
+        '--interval',
+        type=int,
+        default=60,
+        help='Interval in seconds between each scraping (default: 60)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Validation
+    if args.interval < 15:
+        logger.error("Interval must be at least 15 seconds")
+        sys.exit(1)
+    
+    # Lance le scraper continu
+    scraper = ContinuousScraper(interval_seconds=args.interval)
+    scraper.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/scrapy_pyronear/continuous_scraper.py
+++ b/scrapy_pyronear/continuous_scraper.py
@@ -23,101 +23,96 @@ import time
 from pathlib import Path
 
 # Configuration du logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 logger = logging.getLogger(__name__)
 
 
 class ContinuousScraper:
     """Gestionnaire de scraping continu."""
-    
+
     def __init__(self, interval_seconds=30):
         """
         Initialise le scraper continu.
-        
+
         Args:
             interval_seconds (int): Intervalle en secondes entre chaque scraping
         """
         self.interval_seconds = interval_seconds
         self.running = True
         self.scrape_count = 0
-        
+
         # Gestion des signaux pour arrêt propre
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
-    
+
     def _signal_handler(self, signum, frame):
         """Handles stop signals (Ctrl+C, etc.)."""
         logger.info("Stop signal received. Stopping after the current cycle...")
         self.running = False
-    
+
     def run_spider_once(self):
         """
         Lance la spider une seule fois via subprocess.
-        
+
         Returns:
             bool: True si le scraping s'est bien déroulé, False sinon
         """
         try:
             logger.info(f"🚀 Start of scraping cycle #{self.scrape_count + 1}")
             start_time = time.time()
-            
+
             # Lance scrapy crawl en subprocess
             result = subprocess.run(
-                ['scrapy', 'crawl', 'alertwest'],
+                ["scrapy", "crawl", "alertwest"],
                 cwd=Path(__file__).parent,
                 capture_output=False,  # Affiche la sortie en temps réel
-                text=True
+                text=True,
             )
-            
+
             elapsed_time = time.time() - start_time
             self.scrape_count += 1
-            
+
             if result.returncode == 0:
                 logger.info(f"✅ Cycle #{self.scrape_count} finished in {elapsed_time:.2f} seconds")
                 return True
             else:
                 logger.error(f"❌ Cycle #{self.scrape_count} failed with code {result.returncode}")
                 return False
-            
+
         except Exception as e:
             logger.error(f"❌ Error during scraping: {e}", exc_info=True)
             return False
-    
+
     def run(self):
         """Run continuous scraping with the specified interval."""
         logger.info(f"🔄 Starting continuous scraping (interval: {self.interval_seconds}s)")
         logger.info("Press Ctrl+C to stop gracefully")
-        
+
         while self.running:
             cycle_start = time.time()
-            
+
             # Lance un cycle de scraping
             success = self.run_spider_once()
-            
+
             if not self.running:
                 break
-            
+
             # Calcule le temps d'attente avant le prochain cycle
             elapsed = time.time() - cycle_start
             wait_time = max(0, self.interval_seconds - elapsed)
-            
+
             if wait_time > 0:
                 logger.info(f"⏳ Waiting {wait_time:.2f}s before the next cycle...")
-                
+
                 # Temps d'attente avec possibilité d'arrêt
                 sleep_start = time.time()
                 while (time.time() - sleep_start) < wait_time and self.running:
                     time.sleep(min(1, wait_time - (time.time() - sleep_start)))
             else:
                 logger.warning(
-                    f"⚠️  The cycle took {elapsed:.2f}s, "
-                    f"longer than the interval of {self.interval_seconds}s"
+                    f"⚠️  The cycle took {elapsed:.2f}s, longer than the interval of {self.interval_seconds}s"
                 )
-        
+
         logger.info(f"🛑 Stopping continuous scraping. Total cycles completed: {self.scrape_count}")
 
 
@@ -131,27 +126,24 @@ Examples of usage:
   python continuous_scraper.py                    # Default interval (60s)
   python continuous_scraper.py --interval 90      # Every 90 seconds
   python continuous_scraper.py --interval 300     # Every 5 minutes
-        """
+        """,
     )
-    
+
     parser.add_argument(
-        '--interval',
-        type=int,
-        default=60,
-        help='Interval in seconds between each scraping (default: 60)'
+        "--interval", type=int, default=60, help="Interval in seconds between each scraping (default: 60)"
     )
-    
+
     args = parser.parse_args()
-    
+
     # Validation
     if args.interval < 15:
         logger.error("Interval must be at least 15 seconds")
         sys.exit(1)
-    
+
     # Lance le scraper continu
     scraper = ContinuousScraper(interval_seconds=args.interval)
     scraper.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scrapy_pyronear/requirements.txt
+++ b/scrapy_pyronear/requirements.txt
@@ -2,3 +2,4 @@ scrapy==2.13.3
 pytest
 pillow
 tqdm
+ruff

--- a/scrapy_pyronear/scrappy_pyronear/pipelines.py
+++ b/scrapy_pyronear/scrappy_pyronear/pipelines.py
@@ -16,6 +16,7 @@ from twisted.internet.error import TimeoutError, TCPTimedOutError
 from twisted.internet.defer import TimeoutError as DeferTimeoutError
 from twisted.web.client import ResponseNeverReceived
 
+
 class AlertwestImagePipeline(ImagesPipeline):
     """
     Scrapy pipeline for downloading camera images.
@@ -26,20 +27,23 @@ class AlertwestImagePipeline(ImagesPipeline):
     - Handles various failure cases, including timeouts, missing URLs, and cameras that are down.
     - Maintains counters for failed downloads, missing URLs, and timeouts, and reports them when the spider closes.
     """
+
     def open_spider(self, spider):
         self.time = time.time()
         self.spiderinfo = self.SpiderInfo(spider)
         self.total = getattr(spider, "total_cams", 0)
-        self.failed_cam = 0 # counter for failed downloads
-        self.no_url = 0 # counter for missing urls
+        self.failed_cam = 0  # counter for failed downloads
+        self.no_url = 0  # counter for missing urls
         self.timeout_cam = 0  # compteur des timeouts
         self.progress_bar = None
 
     def close_spider(self, spider):
         print(f"\nURL retrieved but camera is down for {self.failed_cam} cameras among {self.total} total cameras.")
-        print(f"Miss a parameter in the json to construct URL for {self.no_url} cameras among {self.total} total cameras.")
+        print(
+            f"Miss a parameter in the json to construct URL for {self.no_url} cameras among {self.total} total cameras."
+        )
         print(f"Timed out for {self.timeout_cam} cameras among {self.total} total cameras.")
-        print(f"Time taken: {(time.time() - self.time)/60:.2f} minutes")
+        print(f"Time taken: {(time.time() - self.time) / 60:.2f} minutes")
         if self.progress_bar:
             self.progress_bar.close()
 
@@ -70,17 +74,17 @@ class AlertwestImagePipeline(ImagesPipeline):
                 total=self.total,
                 desc="Downloading images 🚀 ",
                 bar_format="{l_bar}\033[92m{bar}\033[0m| {n_fmt}/{total_fmt} images",
-                unit="image"
+                unit="image",
             )
 
         url = item["image_url"]
 
         # Skip thermal cameras
-        if "thermal" in item['name'].lower():
+        if "thermal" in item["name"].lower():
             self.progress_bar.update(1)
             return
 
-        if url :
+        if url:
             self.progress_bar.update(1)
             scraped_at = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
             yield scrapy.Request(
@@ -89,10 +93,10 @@ class AlertwestImagePipeline(ImagesPipeline):
                     "id": item["id"],
                     "azimuth": item["azimuth"],
                     "last_moved": item.get("last_moved"),
-                    "scraped_at": item.get("scraped_at", scraped_at)
-                }
+                    "scraped_at": item.get("scraped_at", scraped_at),
+                },
             )
-        else :
+        else:
             self.progress_bar.update(1)
             self.no_url += 1
 

--- a/scrapy_pyronear/scrappy_pyronear/pipelines.py
+++ b/scrapy_pyronear/scrappy_pyronear/pipelines.py
@@ -88,7 +88,7 @@ class AlertwestImagePipeline(ImagesPipeline):
                 meta={
                     "id": item["id"],
                     "azimuth": item["azimuth"],
-                    # "last_moved": item["last_moved"],
+                    "last_moved": item.get("last_moved"),
                     "scraped_at": item.get("scraped_at", scraped_at)
                 }
             )

--- a/scrapy_pyronear/scrappy_pyronear/pipelines.py
+++ b/scrapy_pyronear/scrappy_pyronear/pipelines.py
@@ -6,19 +6,19 @@
 
 # useful for handling different item types with a single interface
 
-import os
-import time
-
 import scrapy
 from scrapy.pipelines.images import ImagesPipeline
 from tqdm import tqdm
+import os
+import time
+from datetime import datetime
+from twisted.internet.error import TimeoutError, TCPTimedOutError
 from twisted.internet.defer import TimeoutError as DeferTimeoutError
-from twisted.internet.error import TCPTimedOutError, TimeoutError
 from twisted.web.client import ResponseNeverReceived
 
-
 class AlertwestImagePipeline(ImagesPipeline):
-    """Scrapy pipeline for downloading camera images.
+    """
+    Scrapy pipeline for downloading camera images.
 
     This pipeline:
     - Downloads images from camera URLs provided in items.
@@ -26,28 +26,26 @@ class AlertwestImagePipeline(ImagesPipeline):
     - Handles various failure cases, including timeouts, missing URLs, and cameras that are down.
     - Maintains counters for failed downloads, missing URLs, and timeouts, and reports them when the spider closes.
     """
-
     def open_spider(self, spider):
         self.time = time.time()
         self.spiderinfo = self.SpiderInfo(spider)
         self.total = getattr(spider, "total_cams", 0)
-        self.failed_cam = 0  # counter for failed downloads
-        self.no_url = 0  # counter for missing urls
+        self.failed_cam = 0 # counter for failed downloads
+        self.no_url = 0 # counter for missing urls
         self.timeout_cam = 0  # compteur des timeouts
         self.progress_bar = None
 
     def close_spider(self, spider):
         print(f"\nURL retrieved but camera is down for {self.failed_cam} cameras among {self.total} total cameras.")
-        print(
-            f"Miss a parameter in the json to construct URL for {self.no_url} cameras among {self.total} total cameras."
-        )
+        print(f"Miss a parameter in the json to construct URL for {self.no_url} cameras among {self.total} total cameras.")
         print(f"Timed out for {self.timeout_cam} cameras among {self.total} total cameras.")
-        print(f"Time taken: {(time.time() - self.time) / 60:.2f} minutes")
+        print(f"Time taken: {(time.time() - self.time)/60:.2f} minutes")
         if self.progress_bar:
             self.progress_bar.close()
 
     def get_media_requests(self, item, info):
-        """Generates Scrapy requests to download images, passing camera metadata.
+        """
+        Generates Scrapy requests to download images, passing camera metadata.
 
         Args:
             item (dict): Dictionary containing image and camera metadata. Expected keys:
@@ -65,7 +63,6 @@ class AlertwestImagePipeline(ImagesPipeline):
 
         Side effects:
             Updates progress bar and counters for missing URLs.
-
         """
         if self.progress_bar is None:
             self.total = info.spider.total_cams
@@ -73,21 +70,29 @@ class AlertwestImagePipeline(ImagesPipeline):
                 total=self.total,
                 desc="Downloading images 🚀 ",
                 bar_format="{l_bar}\033[92m{bar}\033[0m| {n_fmt}/{total_fmt} images",
-                unit="image",
+                unit="image"
             )
 
         url = item["image_url"]
-        if url:
+
+        # Skip thermal cameras
+        if "thermal" in item['name'].lower():
             self.progress_bar.update(1)
+            return
+
+        if url :
+            self.progress_bar.update(1)
+            scraped_at = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
             yield scrapy.Request(
                 url,
                 meta={
                     "id": item["id"],
                     "azimuth": item["azimuth"],
                     "last_moved": item["last_moved"],
-                },
+                    "scraped_at": item.get("scraped_at", scraped_at)
+                }
             )
-        else:
+        else :
             self.progress_bar.update(1)
             self.no_url += 1
 
@@ -101,10 +106,12 @@ class AlertwestImagePipeline(ImagesPipeline):
 
     def file_path(self, request, response=None, info=None, item=None):
 
+        meta = request.meta
         cam_id = str(item.get("id"))
 
         # If there is no azimuth, it is replaced by unknown
         azimuth = str(item.get("azimuth") or "unknown")
-        filename = f"{cam_id}.jpg"
+        scraped_at = str(meta.get("scraped_at") or "unknown")
+        filename = f"{cam_id}_{scraped_at}.jpg"
 
-        return os.path.join(cam_id, azimuth, filename)
+        return os.path.join(cam_id, azimuth, filename)# Define your item pipelines here

--- a/scrapy_pyronear/scrappy_pyronear/pipelines.py
+++ b/scrapy_pyronear/scrappy_pyronear/pipelines.py
@@ -88,7 +88,7 @@ class AlertwestImagePipeline(ImagesPipeline):
                 meta={
                     "id": item["id"],
                     "azimuth": item["azimuth"],
-                    "last_moved": item["last_moved"],
+                    # "last_moved": item["last_moved"],
                     "scraped_at": item.get("scraped_at", scraped_at)
                 }
             )
@@ -114,4 +114,4 @@ class AlertwestImagePipeline(ImagesPipeline):
         scraped_at = str(meta.get("scraped_at") or "unknown")
         filename = f"{cam_id}_{scraped_at}.jpg"
 
-        return os.path.join(cam_id, azimuth, filename)# Define your item pipelines here
+        return os.path.join(cam_id, azimuth, filename)

--- a/scrapy_pyronear/scrappy_pyronear/spiders/alertwest_spider.py
+++ b/scrapy_pyronear/scrappy_pyronear/spiders/alertwest_spider.py
@@ -46,7 +46,7 @@ class AlertwestSpider(scrapy.Spider):
             # Construct image URL
             if cam_id and img_name:
                 date_path = datetime.now().strftime("%Y/%m/%d")
-                img_url = f"https://img.cdn.prod.alertwest.com/data/thumb/{cam_id}/{date_path}/{img_name}"
+                img_url = f"https://img.cdn.prod.alertwest.com/data/img/{cam_id}/{date_path}/{img_name}"
 
             else:
                 img_url = None

--- a/scrapy_pyronear/tests/test_alertwest_image_pipeline.py
+++ b/scrapy_pyronear/tests/test_alertwest_image_pipeline.py
@@ -20,6 +20,7 @@ def test_get_media_requests_with_url(monkeypatch):
 
     item = PyronearItem(
         id="CAM001",
+        name = "Test Camera",
         azimuth=120,
         last_moved=160000,
         image_url="http://example.com/img.jpg"
@@ -34,6 +35,9 @@ def test_get_media_requests_with_url(monkeypatch):
     assert req.meta["id"] == "CAM001"
     assert req.meta["azimuth"] == 120
     assert req.meta["last_moved"] == 160000
+    assert "scraped_at" in req.meta
+    assert isinstance(req.meta["scraped_at"], str)
+    assert len(req.meta["scraped_at"]) > 0
 
 def test_file_path():
     '''
@@ -46,8 +50,9 @@ def test_file_path():
         request = scrapy.Request("http://example.com/img.jpg", meta={
             "id": item["id"],
             "azimuth": item["azimuth"],
-            "last_moved": item["last_moved"]
+            "last_moved": item["last_moved"],
+            "scraped_at": "20250101_120000_123456"
         })
 
         path = pipeline.file_path(request, item=item)
-        assert path == os.path.join("CAM1", "90", "CAM1.jpg")
+        assert path == os.path.join("CAM1", "90", "CAM1_20250101_120000_123456.jpg")

--- a/scrapy_pyronear/tests/test_continuous_scraper.py
+++ b/scrapy_pyronear/tests/test_continuous_scraper.py
@@ -1,0 +1,79 @@
+import signal
+
+import pytest
+
+from continuous_scraper import ContinuousScraper
+
+
+def test_signal_handler_sets_running_false(monkeypatch):
+    # Prevent altering global signal handlers during the test
+    monkeypatch.setattr("continuous_scraper.signal.signal", lambda *_, **__: None)
+
+    scraper = ContinuousScraper(interval_seconds=60)
+    scraper.running = True
+
+    scraper._signal_handler(signal.SIGINT, None)
+
+    assert scraper.running is False
+
+
+def test_run_stops_after_single_cycle_without_wait(monkeypatch):
+    # Prevent altering global signal handlers during the test
+    monkeypatch.setattr("continuous_scraper.signal.signal", lambda *_, **__: None)
+
+    scraper = ContinuousScraper(interval_seconds=60)
+
+    def fake_run_once():
+        scraper.scrape_count += 1
+        scraper.running = False  # stop after the first cycle
+        return True
+
+    monkeypatch.setattr(scraper, "run_spider_once", fake_run_once)
+
+    sleep_calls = []
+    monkeypatch.setattr("continuous_scraper.time.sleep", lambda x: sleep_calls.append(x))
+
+    scraper.run()
+
+    assert scraper.scrape_count == 1
+    assert sleep_calls == []  # no waiting because we stop immediately
+
+
+def test_run_waits_between_cycles_and_stops(monkeypatch):
+    # Prevent altering global signal handlers during the test
+    monkeypatch.setattr("continuous_scraper.signal.signal", lambda *_, **__: None)
+
+    class FakeClock:
+        def __init__(self):
+            self.t = 0
+
+        def time(self):
+            return self.t
+
+        def sleep(self, seconds):
+            # Advance virtual time instead of real sleeping
+            self.t += seconds
+
+    clock = FakeClock()
+    monkeypatch.setattr("continuous_scraper.time.time", clock.time)
+    monkeypatch.setattr("continuous_scraper.time.sleep", clock.sleep)
+
+    scraper = ContinuousScraper(interval_seconds=5)
+
+    def fake_run_once():
+        # Simulate 1s of work per cycle
+        clock.t += 1
+        scraper.scrape_count += 1
+        if scraper.scrape_count >= 2:
+            scraper.running = False  # stop after two cycles
+        return True
+
+    monkeypatch.setattr(scraper, "run_spider_once", fake_run_once)
+
+    scraper.run()
+
+    assert scraper.scrape_count == 2
+    # Expected timeline: after cycle1 t=1, wait ~4s -> t=5; cycle2 adds 1 -> t=6
+    assert clock.time() >= 6
+    # Ensure some waiting occurred (more than just the work time)
+    assert clock.time() > scraper.scrape_count  # waited beyond the 1s per cycle


### PR DESCRIPTION
Changement de l'URL des images afin de télécharger les images et non les thumbnails.
Ajout d'un fichier python continuous_scraper.py afin de gérer le scraping continu. Création des tests associés.
Update du readme et traduction en anglais.
Reformatting ruff.